### PR TITLE
Allow disabling TLS with a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,29 @@ readme = "README.md"
 repository = "https://github.com/little-dude/rmp-rpc"
 version = "0.1.0"
 
+[features]
+default = ["tls"]
+tls = ["native-tls", "tokio-tls"]
+
 [dependencies]
 bytes = "0.4.5"
 futures = "0.1.16"
 log = "0.3.8"
-native-tls = "0.1.4"
 rmpv = "0.4.0"
 tokio-core = "0.1.9"
 tokio-io = "0.1.3"
-tokio-tls = "0.1.3"
 
 [dependencies.clippy]
 optional = true
 version = "0.0.162"
+
+[dependencies.native-tls]
+optional = true
+version = "0.1.4"
+
+[dependencies.tokio-tls]
+optional = true
+version = "0.1.3"
 
 [dev-dependencies]
 env_logger = "0.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,12 @@ extern crate bytes;
 extern crate futures;
 #[macro_use]
 extern crate log;
+#[cfg(feature = "native-tls")]
 extern crate native_tls;
 extern crate rmpv;
 extern crate tokio_core;
 extern crate tokio_io;
+#[cfg(feature = "tokio-tls")]
 extern crate tokio_tls;
 
 mod errors;


### PR DESCRIPTION
TLS pulls in a dependency on OpenSSL, which is rather heavy if it is not
being used. Even if it gets optimized out, it still has to be present at
build time which can be cumbersome in custom/embedded environments
because it is a native library.

Signed-off-by: Tyler Hall <tylerwhall@gmail.com>