### PR TITLE
endpoint: gracefully drop the connection on error

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -369,7 +369,11 @@ where
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         trace!("Polling stream.");
         loop {
-            match self.stream.get_mut().poll().unwrap() {
+            match self.stream.get_mut().poll().unwrap_or_else(|e| {
+                warn!("Error on stream: {}", e);
+                // Drop this connection on error
+                Async::Ready(None)
+            }) {
                 Async::Ready(Some(msg)) => self.handle_message(msg),
                 Async::Ready(None) => {
                     trace!("Stream closed by remote peer.");


### PR DESCRIPTION
We should not kill the server if there is an error on a single stream.

One case this can happen is if the client sets SO_LINGER to 0 before
closing its socket. The client will send a RST packet and the server
will get "Connection reset by peer" rather than a normal end of stream.

I have another set of changes coming to add a test for this but it requires more infrastructure changes to support it.