### PR TITLE
Warning/CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: rust
 
+rust:
+    - stable
+    - beta
+    - nightly
+
 matrix:
     fast_finish: true
     allow_failures:
         - rust: nightly
     include:
-        - rust: stable
-          env: RUNCMD="cargo test"
-        - rust: beta
-          env: RUNCMD="cargo test"
         - rust: nightly
-          env: RUNCMD="cargo test --features clippy"
+          before_script:
+          - rustup component add clippy-preview
+          script:
+          - cargo clippy --verbose -- -D warnings
         - os: osx
           rust: stable
-          env: RUNCMD="cargo test"
 
 sudo: false
 dist: trusty
@@ -23,9 +26,6 @@ cache:
   directories:
     - target/debug/deps
     - target/debug/build
-
-script:
-  - $RUNCMD
 
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ bytes = "^0.4"
 futures = "^0.1"
 log = "^0.4"
 rmpv = "^0.4"
-tokio-core = "^0.1"
-tokio-io = "^0.1"
+tokio = "^0.1"
+tokio-core = "^0.1.17"
 
 [dependencies.clippy]
 optional = true

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -17,8 +17,8 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
 use futures::{future, Future, Stream};
-use tokio_core::reactor::Core;
 use tokio_core::net::{TcpListener, TcpStream};
+use tokio_core::reactor::Core;
 
 use rmp_rpc::{Client, Endpoint, ServiceWithClient, Value};
 
@@ -124,6 +124,7 @@ fn main() {
                     .map(|_| ())
                     .map_err(|_| ())
             }),
-    ).unwrap();
+    )
+    .unwrap();
     println!("Received {} pongs", pongs.lock().unwrap());
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2,7 +2,7 @@ use bytes::BytesMut;
 use errors::DecodeError;
 use message::Message;
 use std::io;
-use tokio_io::codec::{Decoder, Encoder};
+use tokio::codec::{Decoder, Encoder};
 
 #[derive(Debug)]
 pub struct Codec;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,8 +1,8 @@
-use std::io;
 use bytes::BytesMut;
-use tokio_io::codec::{Decoder, Encoder};
 use errors::DecodeError;
 use message::Message;
+use std::io;
+use tokio_io::codec::{Decoder, Encoder};
 
 #[derive(Debug)]
 pub struct Codec;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 use std::io;
 
-use futures::{Async, AsyncSink, Future, IntoFuture, Poll, Sink, StartSend, Stream};
 use futures::sync::{mpsc, oneshot};
+use futures::{Async, AsyncSink, Future, IntoFuture, Poll, Sink, StartSend, Stream};
+use rmpv::Value;
 use tokio_core::reactor;
 use tokio_io::codec::Framed;
 use tokio_io::{AsyncRead, AsyncWrite};
-use rmpv::Value;
 
-use message::{Message, Notification, Request};
-use message::Response as MsgPackResponse;
 use codec::Codec;
+use message::Response as MsgPackResponse;
+use message::{Message, Notification, Request};
 
 // We need this IntoStaticFuture trait because the future we spawn on Tokio's event loop must have
 // the 'static lifetime.
@@ -480,7 +480,8 @@ impl MessageHandler for InnerClient {
     }
 
     fn is_finished(&self) -> bool {
-        self.client_closed && self.pending_requests.is_empty()
+        self.client_closed
+            && self.pending_requests.is_empty()
             && self.pending_notifications.is_empty()
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
-use std::{error, fmt, io};
 use rmpv::decode;
+use std::{error, fmt, io};
 
 /// Error while decoding a sequence of bytes into a `MessagePack-RPC` message
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,12 @@ extern crate rmpv;
 extern crate tokio_core;
 extern crate tokio_io;
 
-mod errors;
 mod codec;
-pub mod message;
 mod endpoint;
+mod errors;
+pub mod message;
 
-pub use endpoint::{serve, Ack, Client, Endpoint, IntoStaticFuture, Response, Service,
-                   ServiceWithClient};
+pub use endpoint::{
+    serve, Ack, Client, Endpoint, IntoStaticFuture, Response, Service, ServiceWithClient,
+};
 pub use rmpv::{Integer, Utf8String, Value};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ extern crate futures;
 #[macro_use]
 extern crate log;
 extern crate rmpv;
+extern crate tokio;
 extern crate tokio_core;
-extern crate tokio_io;
 
 mod codec;
 mod endpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,5 @@
 //! This crate provides facilities to use the `MessagePack` remote procedure call system
 //! (`MessagePack-RPC`) in Rust.
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "clippy", deny(clippy))]
-#![cfg_attr(feature = "clippy", allow(missing_docs_in_private_items))]
-#![cfg_attr(feature = "clippy", allow(type_complexity))]
 
 extern crate bytes;
 extern crate futures;

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,9 +3,8 @@ use rmpv::{decode, encode, Integer, Utf8String, Value};
 use std::convert::From;
 use std::io::{self, Read};
 
-/// Represents a `MessagePack-RPC` message as described in the [specifications][specs].
-///
-/// [specs]: (https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md#messagepack-rpc-protocol-specification)
+/// Represents a `MessagePack-RPC` message as described in the
+/// [specifications](https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md#messagepack-rpc-protocol-specification).
 #[derive(PartialEq, Clone, Debug)]
 pub enum Message {
     Request(Request),
@@ -13,7 +12,8 @@ pub enum Message {
     Notification(Notification),
 }
 
-/// Represents a `MessagePack-RPC` request as described in the [specifications][specs].
+/// Represents a `MessagePack-RPC` request as described in the
+/// [specifications](https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md#messagepack-rpc-protocol-specification).
 ///
 /// A request is a message that a client sends to a server when it expects a response. Sending a
 /// request is like calling a method: it includes a method name and an array of parameters. The
@@ -29,7 +29,8 @@ pub struct Request {
     pub params: Vec<Value>,
 }
 
-/// Represents a `MessagePack-RPC` response as described in the [specifications][specs].
+/// Represents a `MessagePack-RPC` response as described in the
+/// [specifications](https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md#messagepack-rpc-protocol-specification).
 ///
 /// After a client sends a [`Request`], the server will send a response back.
 #[derive(PartialEq, Clone, Debug)]
@@ -40,7 +41,8 @@ pub struct Response {
     pub result: Result<Value, Value>,
 }
 
-/// Represents a `MessagePack-RPC` notification as described in the [specifications][specs].
+/// Represents a `MessagePack-RPC` notification as described in the
+/// [specifications](https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md#messagepack-rpc-protocol-specification).
 ///
 /// A notification is a message that a client sends to a server when it doesn't expect a response.
 /// Sending a notification is like calling a method with no return value: the notification includes

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use errors::*;
-use std::io::{self, Read};
 use rmpv::{decode, encode, Integer, Utf8String, Value};
 use std::convert::From;
+use std::io::{self, Read};
 
 /// Represents a `MessagePack-RPC` message as described in the [specifications][specs].
 ///


### PR DESCRIPTION
Account for changes in Rust tooling.

Format, fix deprecation warning, doc warning, and update how clippy runs in Travis.