### PR TITLE
Update from tokio-core to tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ futures = "^0.1"
 log = "^0.4"
 rmpv = "^0.4"
 tokio = "^0.1"
-tokio-core = "^0.1.17"
 
 [dependencies.clippy]
 optional = true

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -30,7 +30,7 @@ fn main() {
             Err(())
         })
         .and_then(move |stream| {
-            let client = Client::new(stream, &handle);
+            let client = Client::new(stream);
 
             // Use the client to send a notification.
             // The future returned by client.notify() finishes when the notification

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -40,7 +40,7 @@ impl PingPong {
 // Implement how the endpoint handles incoming requests and notifications.
 // In this example, the endpoint does not handle notifications.
 impl ServiceWithClient for PingPong {
-    type RequestFuture = Box<Future<Item = Value, Error = Value> + 'static>;
+    type RequestFuture = Box<Future<Item = Value, Error = Value> + 'static + Send>;
 
     fn handle_request(
         &mut self,

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -93,7 +93,7 @@ fn main() {
     // Spawn a "remote" endpoint on the Tokio event loop
     handle.clone().spawn(
         listener
-            .for_each(move |(stream, _addr)| Endpoint::new(stream, PingPong::new(), handle.clone()))
+            .for_each(move |(stream, _addr)| Endpoint::new(stream, PingPong::new()))
             .map_err(|_| ()),
     );
 
@@ -105,7 +105,7 @@ fn main() {
             .map_err(|_| ())
             .and_then(|stream| {
                 // Make a "local" endpoint.
-                let endpoint = Endpoint::new(stream, ping_pong_client, handle.clone());
+                let endpoint = Endpoint::new(stream, ping_pong_client);
                 let client = endpoint.client();
                 let mut requests = vec![];
                 for i in 0..10 {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -68,7 +68,7 @@ fn main() {
         .incoming()
         // Each time the listener finds a new connection, start up a server to handle it.
         .for_each(move |(stream, _addr)| {
-            serve(stream, Echo, handle.clone())
+            serve(stream, Echo)
         });
 
     // Run the server on the tokio event loop. This is blocking. Press ^C to stop

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,14 +4,13 @@
 //! notifications to the remote endpoint.
 extern crate futures;
 extern crate rmp_rpc;
-extern crate tokio_core;
+extern crate tokio;
 
 use std::net::SocketAddr;
 
-use futures::Stream;
+use futures::{Future, Stream};
 use rmp_rpc::{serve, Service, Value};
-use tokio_core::net::TcpListener;
-use tokio_core::reactor::Core;
+use tokio::net::TcpListener;
 
 // Our server type
 #[derive(Clone)]
@@ -58,19 +57,16 @@ impl Service for Echo {
 
 fn main() {
     let addr: SocketAddr = "127.0.0.1:54321".parse().unwrap();
-    // Create a tokio event loop.
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-
     // Create a listener to listen for incoming TCP connections.
-    let server = TcpListener::bind(&addr, &handle)
+    let server = TcpListener::bind(&addr)
         .unwrap()
         .incoming()
         // Each time the listener finds a new connection, start up a server to handle it.
-        .for_each(move |(stream, _addr)| {
-            serve(stream, Echo)
+        .map_err(|e| println!("error on TcpListener: {}", e))
+        .for_each(move |stream| {
+            serve(stream, Echo).map_err(|e| println!("server error {}", e))
         });
 
     // Run the server on the tokio event loop. This is blocking. Press ^C to stop
-    core.run(server).unwrap();
+    tokio::run(server);
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -44,7 +44,7 @@ where
 }
 
 /// The `Service` trait defines how a `MessagePack-RPC` server handles requests and notifications.
-pub trait Service {
+pub trait Service: Send {
     /// The type of future returned by `handle_request`. This future will be spawned on the event
     /// loop, and when it is complete then the result will be sent back to the client that made the
     /// request.
@@ -567,10 +567,10 @@ impl<MH: MessageHandler, T: AsyncRead + AsyncWrite> Future for InnerEndpoint<MH,
 ///
 /// The returned future will run until the stream is closed; if the stream encounters an error,
 /// then the future will propagate it and terminate.
-pub fn serve<'a, S: Service + 'a, T: AsyncRead + AsyncWrite + 'a>(
+pub fn serve<'a, S: Service + 'a, T: AsyncRead + AsyncWrite + 'a + Send>(
     stream: T,
     service: S,
-) -> Box<Future<Item = (), Error = io::Error> + 'a> {
+) -> Box<Future<Item = (), Error = io::Error> + 'a + Send> {
     Box::new(ServerEndpoint::new(stream, service))
 }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -570,8 +570,8 @@ impl<MH: MessageHandler, T: AsyncRead + AsyncWrite> Future for InnerEndpoint<MH,
 pub fn serve<'a, S: Service + 'a, T: AsyncRead + AsyncWrite + 'a + Send>(
     stream: T,
     service: S,
-) -> Box<Future<Item = (), Error = io::Error> + 'a + Send> {
-    Box::new(ServerEndpoint::new(stream, service))
+) -> impl Future<Item = (), Error = io::Error> + 'a + Send {
+    ServerEndpoint::new(stream, service)
 }
 
 struct ServerEndpoint<S: Service, T: AsyncRead + AsyncWrite> {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -731,23 +731,23 @@ impl Client {
     /// ```
     /// extern crate futures;
     /// extern crate rmp_rpc;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
+    ///
+    /// use std::net::SocketAddr;
     ///
     /// use futures::Future;
-    /// use std::net::SocketAddr;
     /// use rmp_rpc::Client;
-    /// use tokio_core::net::TcpStream;
-    /// use tokio_core::reactor::Core;
+    /// use tokio::net::TcpStream;
     ///
     /// fn main() {
-    ///     let mut core = Core::new().unwrap();
     ///     let addr: SocketAddr = "127.0.0.1:54321".parse().unwrap();
-    ///     let handle = core.handle();
     ///
-    ///     // Open a TCP connection.
-    ///     let connect = TcpStream::connect(&addr, &handle)
-    ///         .map_err(|e| println!("I/O error: {}", e))
-    ///         // Once we get the connection, start a new client on it.
+    ///     // Create a future that connects to the server, and send a notification and a request.
+    ///     let client = TcpStream::connect(&addr)
+    ///         .or_else(|e| {
+    ///             println!("I/O error in the client: {}", e);
+    ///             Err(())
+    ///         })
     ///         .and_then(move |stream| {
     ///             let client = Client::new(stream);
     ///
@@ -756,8 +756,8 @@ impl Client {
     ///             // has been sent, in case we care about that. We can also just drop it.
     ///             client.notify("hello", &[]);
     ///
-    ///             // Use the client to send a request with the method "dostuff", and two
-    ///             // parameters: the string "foo" and the integer "42".
+    ///             // Use the client to send a request with the method "dostuff", and two parameters:
+    ///             // the string "foo" and the integer "42".
     ///             // The future returned by client.request() finishes when the response
     ///             // is received.
     ///             client
@@ -767,9 +767,10 @@ impl Client {
     ///                     Ok(())
     ///                 })
     ///         });
+    ///
     ///     // Uncomment this to run the client, blocking until the response was received and the
     ///     // message was printed.
-    ///     // core.run(connect).unwrap();
+    ///     // tokio::run(client);
     /// }
     /// ```
     /// # Panics

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -20,7 +20,7 @@ use message::{Message, Notification, Request};
 /// in that the returned future has the `'static` lifetime.
 pub trait IntoStaticFuture {
     /// The future that this type can be converted into.
-    type Future: Future<Item = Self::Item, Error = Self::Error> + 'static;
+    type Future: Future<Item = Self::Item, Error = Self::Error> + 'static + Send;
     /// The item that the future may resolve with.
     type Item;
     /// The error that the future may resolve with.
@@ -32,7 +32,7 @@ pub trait IntoStaticFuture {
 
 impl<F: IntoFuture> IntoStaticFuture for F
 where
-    <F as IntoFuture>::Future: 'static,
+    <F as IntoFuture>::Future: 'static + Send,
 {
     type Future = <F as IntoFuture>::Future;
     type Item = <F as IntoFuture>::Item;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate futures;
 extern crate log;
 extern crate rmpv;
 extern crate tokio;
-extern crate tokio_core;
 
 mod codec;
 mod endpoint;


### PR DESCRIPTION
This is an API breaking change. The structure of the API is unchanged, but the main changes are
- Remove references to `tokio_core::reactor::Handle`. This is used for spawn(), and in new tokio this is done through thread local storage from `tokio::spawn()`.
- Add `Send` trait bounds to returned futures and the `Service` trait. New tokio wants all futures to be send. This didn't drive any changes within the library, but the new bounds could affect clients that implement `Service`.

I wanted to make a transition point that supported both tokio versions by leaving the old tokio_core handle in the API but using the new `tokio::spawn()` internally. This would have worked since current tokio_core is implemented on top of tokio, but the `Send` trait bound made this impossible. We need the client to implement `Send` in order to for the library to interact directly with new tokio, so I could not find a way to stage this.

When updating, clients will need to make sure their Service trait is `Send` and remove the `Handle` in init functions. They can continue to use tokio-core, however, so updating this library can be done without converting the rest of a project at the same time.

Depends on #17 